### PR TITLE
refactor: update capacity provider construct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 cdk.out
 cdk.context.json
 .env*
+.idea/

--- a/README.md
+++ b/README.md
@@ -31,22 +31,11 @@ With the environment variables all set, you can just run this stack with:
 npx cdk deploy --all --require-approval never
 ```
 
-As of now, you need to add the capacityProvider in the fresh cluster via console or aws CLI. AWS does not support CDK Capacity Provider for now:
+## Attach capacityProvider to your cluster
 
-- https://github.com/aws/aws-cdk/issues/5471
-- https://aws.amazon.com/pt/blogs/containers/deep-dive-on-amazon-ecs-cluster-auto-scaling/
-- https://ecsworkshop.com/capacity_providers/
+As of now, you need to configure the default [capacityProvider](https://aws.amazon.com/pt/blogs/containers/deep-dive-on-amazon-ecs-cluster-auto-scaling/) via console or aws CLI. AWS does not support CDK Capacity Provider for now.
 
 So you will need to execute the following steps via [AWS CLI](https://docs.aws.amazon.com/pt_br/cli/latest/userguide/install-cliv2.html).
-
-## Creating capacity provider
-```sh
-    aws ecs create-capacity-provider \
-        --name $capacity_provider_name \
-        --auto-scaling-group-provider autoScalingGroupArn="$asg_arn",managedScaling=\{status="ENABLED",targetCapacity=100\},managedTerminationProtection="DISABLED" \
-        --region $AWS_REGION
-```
-## Attach it your cluster
 
 ```sh
 aws ecs put-cluster-capacity-providers \
@@ -55,11 +44,4 @@ aws ecs put-cluster-capacity-providers \
     --default-capacity-provider-strategy capacityProvider=default,weight=1,base=1
 ```
 
-You should still manually update de ASG with `managedTerminationProtection` so you can also enable it on your CapacityProvider. This is useful because
-your cluster can protect instances with running tasks to be removed. ASG by default doesn't know/care about this, so you could end up with interrupted long running tasks.
-
-**Please note that** since only the base stack is handled by CDK, it is not safe to run updates: ASG changes will erase further modifications, such as the CapacityProvider link into the cluster and `managedTerminationProtection` changes. We intend to handle this better as soon as AWS publishes the missing CDK constructors. 
-
-## Future plans:
-
-- [ ] have the cli/manual steps automated using [AWS JS SDK](https://aws.amazon.com/sdk-for-node-js/).
+**Please note that** since only the base stack is handled by CDK, it is not safe to run updates: ASG changes will erase further modifications, such as the CapacityProvider link into the cluster. We intend to handle this better as soon as AWS publishes the missing CDK constructors. 

--- a/cluster.ts
+++ b/cluster.ts
@@ -1,8 +1,7 @@
-import {  Cluster } from '@aws-cdk/aws-ecs';
-import {  BlockDeviceVolume } from '@aws-cdk/aws-autoscaling';
-import {  Vpc, InstanceType, InstanceClass, InstanceSize, Subnet, LookupMachineImage} from '@aws-cdk/aws-ec2';
-import {  App, Stack, StackProps, Duration } from '@aws-cdk/core';
-
+import { Cluster, AsgCapacityProvider } from '@aws-cdk/aws-ecs';
+import { AutoScalingGroup, BlockDeviceVolume, UpdatePolicy, Monitoring } from '@aws-cdk/aws-autoscaling';
+import { Vpc, InstanceType, Subnet, LookupMachineImage } from '@aws-cdk/aws-ec2';
+import { App, Stack, StackProps, Duration } from '@aws-cdk/core';
 
 export class ECSCluster extends Stack {
   constructor(scope: App, id: string, props?: StackProps) {
@@ -26,20 +25,27 @@ export class ECSCluster extends Stack {
 
     const ami = new LookupMachineImage( { name: 'passeidireto-ecs-sysbox*' });
 
-    const asg = cluster.addCapacity('gh-runner-automanaged', {
-      instanceType: InstanceType.of(InstanceClass.T2, InstanceSize.XLARGE),
+    const asg: AutoScalingGroup = new AutoScalingGroup(this, 'Asg', {
+      vpc,
+      autoScalingGroupName: 'gh-runner-automanaged',
+      instanceType: new InstanceType('t3.xlarge'),
       machineImage: ami,
       minCapacity: 0,
       maxCapacity: 6,
-      taskDrainTime: Duration.minutes(1),
-      cooldown: Duration.minutes(1),
+      cooldown: Duration.seconds(60),
+      blockDevices: [{
+        deviceName: '/dev/xvda',
+        volume: BlockDeviceVolume.ebs(40),
+      }],
       vpcSubnets: {
         subnets,
       },
-      blockDevices:[{
-        deviceName: "/dev/sda1",
-        volume: BlockDeviceVolume.ebs(40)
-      }]
+      newInstancesProtectedFromScaleIn: true,
+      maxInstanceLifetime: Duration.days(7),
+      updatePolicy: UpdatePolicy.replacingUpdate(),
+      instanceMonitoring: Monitoring.DETAILED,
+      // https://github.com/aws/aws-cdk/issues/11581
+      updateType: undefined,
     });
 
     asg.addUserData(
@@ -58,7 +64,17 @@ export class ECSCluster extends Stack {
       'curl -o ecs-agent.tar https://s3.us-east-2.amazonaws.com/amazon-ecs-agent-us-east-2/ecs-agent-latest.tar',
       'docker load --input ./ecs-agent.tar',
       'docker run --name ecs-agent --privileged --detach=true --restart=on-failure:10 --volume=/var/run:/var/run --volume=/var/log/ecs/:/log:Z --volume=/var/lib/ecs/data:/data:Z --volume=/etc/ecs:/etc/ecs --net=host --userns=host --runtime=runc --env-file=/etc/ecs/ecs.config amazon/amazon-ecs-agent:latest'
-      );
+    );
+
+    const capacityProvider = new AsgCapacityProvider(this, 'AsgCapacityProvider', {
+      autoScalingGroup: asg,
+      enableManagedScaling: true,
+      enableManagedTerminationProtection: true,
+      targetCapacityPercent: 100,
+      capacityProviderName: asg.autoScalingGroupName,
+    });
+
+    cluster.addAsgCapacityProvider(capacityProvider);
   }
 }
 

--- a/cluster.ts
+++ b/cluster.ts
@@ -35,7 +35,7 @@ export class ECSCluster extends Stack {
       cooldown: Duration.seconds(60),
       blockDevices: [{
         deviceName: '/dev/xvda',
-        volume: BlockDeviceVolume.ebs(40),
+        volume: BlockDeviceVolume.ebs(200),
       }],
       vpcSubnets: {
         subnets,


### PR DESCRIPTION
- Ativar proteção contra scale-in nas intâncias do ASG (sem isso a proteção do Capacity Provider do ECS não funciona)
- Configurar Capacity Provider via CDK (disponível na versão 1.105 do CDK)
- Alterar o storage device de `/dev/sda1` para o padrão `/dev/xvda` (o /dev/sda1 não devia estar sendo utilizado)
- Alterar instâncias do tipo t2 para t3 (instância mais moderna com mais crédito e melhor tráfego de rede)

Pendências
- Definir Capacity Provider como default